### PR TITLE
Fix decoding with start_frame and end_frame

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "video_reader-rs"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 
 [lib]

--- a/src/video_io.rs
+++ b/src/video_io.rs
@@ -70,7 +70,12 @@ impl VideoDecoder {
     ) -> Result<(), ffmpeg::Error> {
         let mut decoded = Video::empty();
         while self.decoder.receive_frame(&mut decoded).is_ok() {
-            if reducer.indices.iter().any(|x| x == &reducer.frame_index) {
+            let match_index = reducer
+                .indices
+                .iter()
+                .position(|x| x == &reducer.frame_index);
+            if match_index.is_some() {
+                reducer.indices.remove(match_index.unwrap());
                 let mut rgb_frame = Video::empty();
                 self.scaler.run(&decoded, &mut rgb_frame)?;
                 let nd_frame = convert_frame_to_ndarray_rgb24(&mut rgb_frame);
@@ -257,7 +262,7 @@ impl VideoReader {
         ))
     }
 
-    pub fn decode_video<'a>(mut self) -> Result<VideoArray, ffmpeg::Error> {
+    pub fn decode_video(mut self) -> Result<VideoArray, ffmpeg::Error> {
         let first_index = self.first_frame.unwrap_or(0);
         let mut seeked = false;
         let mut first_frame: FrameArray =
@@ -284,10 +289,11 @@ impl VideoReader {
                         .full_video
                         .slice_mut(s![reducer.idx_counter, .., .., ..])
                         .assign(&first_frame);
+                    reducer.indices.remove(0);
                     reducer.idx_counter += 1;
                 }
                 for (stream, packet) in self.ictx.packets() {
-                    if &reducer.frame_index > reducer.indices.iter().max().unwrap() {
+                    if &reducer.frame_index > reducer.indices.iter().max().unwrap_or(&0) {
                         break;
                     }
                     if stream.index() == self.stream_index {
@@ -300,7 +306,9 @@ impl VideoReader {
                 }
                 self.decoder.decoder.send_eof()?;
                 // only process the remaining frames if we haven't reached the last frame
-                if &reducer.frame_index <= reducer.indices.iter().max().unwrap() {
+                if (reducer.indices.len() != 0)
+                    && (&reducer.frame_index <= reducer.indices.iter().max().unwrap_or(&0))
+                {
                     self.decoder
                         .receive_and_process_decoded_frames(&mut reducer)?;
                 }
@@ -586,7 +594,6 @@ impl VideoReader {
                     let ts = key_pos * frame_duration;
                     let range = (ts - frame_duration / 2) as i64..(ts + frame_duration / 2) as i64;
                     self.ictx.seek(ts as i64, range)?;
-                    // self.seek_frame(&key_pos, frame_duration)?;
                     self.curr_frame = key_pos;
                     self.seek_accurate(frame_index, frame_duration)
                 } else {
@@ -666,7 +673,6 @@ impl VideoReader {
     // AVSEEK_FLAG_ANY 4 <- seek to any frame, even non-key frames
     // AVSEEK_FLAG_FRAME 8 <- seeking baseed on frame number
     pub fn seek_frame(&mut self, pos: &usize, frame_duration: &usize) -> Result<(), ffmpeg::Error> {
-        // let frame_ts = pos * frame_duration;
         let frame_ts = match self.stream_info.frame_times.get(pos) {
             Some(fr_ts) => fr_ts.pts,
             None => (pos * frame_duration) as i64,

--- a/src/video_io.rs
+++ b/src/video_io.rs
@@ -299,6 +299,7 @@ impl VideoReader {
                     }
                 }
                 self.decoder.decoder.send_eof()?;
+                // only process the remaining frames if we haven't reached the last frame
                 if &reducer.frame_index <= reducer.indices.iter().max().unwrap() {
                     self.decoder
                         .receive_and_process_decoded_frames(&mut reducer)?;

--- a/src/video_io.rs
+++ b/src/video_io.rs
@@ -306,7 +306,7 @@ impl VideoReader {
                 }
                 self.decoder.decoder.send_eof()?;
                 // only process the remaining frames if we haven't reached the last frame
-                if (reducer.indices.len() != 0)
+                if reducer.indices.is_empty()
                     && (&reducer.frame_index <= reducer.indices.iter().max().unwrap_or(&0))
                 {
                     self.decoder


### PR DESCRIPTION
- Only seek if we really need to, ie first_index is after first key frame.
- `reducer.frame_index` was incorrect after seeking so we set it to `self.curr_frame`.
- First frame was not inserted in the video array.