### PR TITLE
Temporary Fix for Windows Wheels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,6 +126,7 @@ jobs:
           7z x -y -o"$env:FFMPEG_INSTALL_PATH" "$tempFile"
           $ffmpegDir = (Get-ChildItem -Directory "$env:FFMPEG_INSTALL_PATH").FullName
           Add-Content $env:GITHUB_ENV "FFMPEG_DIR=$ffmpegDir"
+          # Add FFmpeg bin to PATH so delvewheel can find the DLLs
           Add-Content $env:GITHUB_PATH "$ffmpegDir/bin"
 
       - uses: actions/setup-python@v5
@@ -133,18 +134,30 @@ jobs:
           python-version: '3.11'
           architecture: ${{ matrix.platform.target }}
 
-      - name: Build wheels
+      # Install delvewheel
+      - name: Install build dependencies
+        run: pip install delvewheel
+
+      - name: Build wheel
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
           args: --release --features ffmpeg_6_0 --out dist --find-interpreter
           sccache: 'true'
 
+      - name: Repair wheel with delvewheel
+        shell: bash
+        run: |
+          # delvewheel needs the DLLs in PATH, which was done in the 'Install FFmpeg' step
+          delvewheel repair dist/*.whl
+
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
           name: wheels-windows-${{ matrix.platform.target }}
-          path: dist
+          path: wheelhouse/
+  
+  # ... existing code ...
 
   macos:
     runs-on: ${{ matrix.platform.runner }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,7 +126,6 @@ jobs:
           7z x -y -o"$env:FFMPEG_INSTALL_PATH" "$tempFile"
           $ffmpegDir = (Get-ChildItem -Directory "$env:FFMPEG_INSTALL_PATH").FullName
           Add-Content $env:GITHUB_ENV "FFMPEG_DIR=$ffmpegDir"
-          # Add FFmpeg bin to PATH so delvewheel can find the DLLs
           Add-Content $env:GITHUB_PATH "$ffmpegDir/bin"
 
       - uses: actions/setup-python@v5
@@ -134,7 +133,6 @@ jobs:
           python-version: '3.11'
           architecture: ${{ matrix.platform.target }}
 
-      # Install delvewheel
       - name: Install build dependencies
         run: pip install delvewheel
 
@@ -148,7 +146,6 @@ jobs:
       - name: Repair wheel with delvewheel
         shell: bash
         run: |
-          # delvewheel needs the DLLs in PATH, which was done in the 'Install FFmpeg' step
           delvewheel repair dist/*.whl
 
       - name: Upload wheels
@@ -157,8 +154,6 @@ jobs:
           name: wheels-windows-${{ matrix.platform.target }}
           path: wheelhouse/
   
-  # ... existing code ...
-
   macos:
     runs-on: ${{ matrix.platform.runner }}
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,7 +153,7 @@ jobs:
         with:
           name: wheels-windows-${{ matrix.platform.target }}
           path: wheelhouse/
-  
+
   macos:
     runs-on: ${{ matrix.platform.runner }}
     strategy:


### PR DESCRIPTION
This PR adresses #52 and #11 

This uses delvewheel to scan the .whl and check for the missing .dll
![image](https://github.com/user-attachments/assets/f847a130-2453-415c-9939-ef76f3ed3fd3)

Should be a temporary fix until you can figure out why the windows wheel don't work, 

Also I've noticed that the macos wheels are also quite small in comparison to linux, might be worth using delvewheel on them too and using a GH Runner try to check if macos works. 