### PR TITLE
Add the laying groundwork for frame iteration 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,7 @@ jobs:
     env:
       FFMPEG_DOWNLOAD_URL: "https://github.com/GyanD/codexffmpeg/releases/download/VER/ffmpeg-VER-full_build-shared.7z"
       FFMPEG_INSTALL_PATH: "C:/ffmpeg"
-      FFMPEG_VERSION: "7.1.1"
+      FFMPEG_VERSION: "7.1"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,7 @@ jobs:
     env:
       FFMPEG_DOWNLOAD_URL: "https://github.com/GyanD/codexffmpeg/releases/download/VER/ffmpeg-VER-full_build-shared.7z"
       FFMPEG_INSTALL_PATH: "C:/ffmpeg"
-      FFMPEG_VERSION: "7.0"
+      FFMPEG_VERSION: "7.1.1"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,6 +126,7 @@ jobs:
           7z x -y -o"$env:FFMPEG_INSTALL_PATH" "$tempFile"
           $ffmpegDir = (Get-ChildItem -Directory "$env:FFMPEG_INSTALL_PATH").FullName
           Add-Content $env:GITHUB_ENV "FFMPEG_DIR=$ffmpegDir"
+          # Add FFmpeg bin to PATH so delvewheel can find the DLLs
           Add-Content $env:GITHUB_PATH "$ffmpegDir/bin"
 
       - uses: actions/setup-python@v5
@@ -133,18 +134,30 @@ jobs:
           python-version: '3.11'
           architecture: ${{ matrix.platform.target }}
 
-      - name: Build wheels
+      # Install delvewheel
+      - name: Install build dependencies
+        run: pip install delvewheel
+
+      - name: Build wheel
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
           args: --release --features ffmpeg_6_0 --out dist --find-interpreter
           sccache: 'true'
 
+      - name: Repair wheel with delvewheel
+        shell: bash
+        run: |
+          # delvewheel needs the DLLs in PATH, which was done in the 'Install FFmpeg' step
+          delvewheel repair dist/*.whl
+
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
           name: wheels-windows-${{ matrix.platform.target }}
-          path: dist
+          path: wheelhouse/
+  
+  # ... existing code ...
 
   macos:
     runs-on: ${{ matrix.platform.runner }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,7 @@ jobs:
     env:
       FFMPEG_DOWNLOAD_URL: "https://github.com/GyanD/codexffmpeg/releases/download/VER/ffmpeg-VER-full_build-shared.7z"
       FFMPEG_INSTALL_PATH: "C:/ffmpeg"
-      FFMPEG_VERSION: "7.1"
+      FFMPEG_VERSION: "7.0"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,7 +126,6 @@ jobs:
           7z x -y -o"$env:FFMPEG_INSTALL_PATH" "$tempFile"
           $ffmpegDir = (Get-ChildItem -Directory "$env:FFMPEG_INSTALL_PATH").FullName
           Add-Content $env:GITHUB_ENV "FFMPEG_DIR=$ffmpegDir"
-          # Add FFmpeg bin to PATH so delvewheel can find the DLLs
           Add-Content $env:GITHUB_PATH "$ffmpegDir/bin"
 
       - uses: actions/setup-python@v5
@@ -134,7 +133,6 @@ jobs:
           python-version: '3.11'
           architecture: ${{ matrix.platform.target }}
 
-      # Install delvewheel
       - name: Install build dependencies
         run: pip install delvewheel
 
@@ -148,7 +146,6 @@ jobs:
       - name: Repair wheel with delvewheel
         shell: bash
         run: |
-          # delvewheel needs the DLLs in PATH, which was done in the 'Install FFmpeg' step
           delvewheel repair dist/*.whl
 
       - name: Upload wheels
@@ -157,8 +154,6 @@ jobs:
           name: wheels-windows-${{ matrix.platform.target }}
           path: wheelhouse/
   
-  # ... existing code ...
-
   macos:
     runs-on: ${{ matrix.platform.runner }}
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,7 +153,7 @@ jobs:
         with:
           name: wheels-windows-${{ matrix.platform.target }}
           path: wheelhouse/
-  
+
   macos:
     runs-on: ${{ matrix.platform.runner }}
     strategy:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+*.whl
+
 /target
 target/
 debug/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "video_reader-rs"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",

--- a/scripts/test_frame_iterator.py
+++ b/scripts/test_frame_iterator.py
@@ -7,7 +7,7 @@ try:
     import numpy as np
     from decord import VideoReader
 except ImportError:
-    raise ImportError("Please install the required packages: `pip install numpy decord tqdm opencv-python`")
+    raise ImportError("Please install the required packages: `pip install numpy decord`")
 
 
 def parse_args():

--- a/scripts/test_frame_iterator.py
+++ b/scripts/test_frame_iterator.py
@@ -1,0 +1,103 @@
+import argparse
+from pathlib import Path
+from video_reader import PyVideoReader
+
+
+try:
+    import numpy as np
+    from decord import VideoReader
+except ImportError:
+    raise ImportError("Please install the required packages: `pip install numpy decord tqdm opencv-python`")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Benchmarking video_reader vs decord")
+    parser.add_argument("--filename", "-f", type=str, help="Path to the video file or directory containing video files")
+    parser.add_argument("--batch_size", "-b", type=int, default=32, help="Number of frames in each batch")
+    parser.add_argument("--num_batches", "-n", type=int, default=5, help="Number of batches to test")
+    return parser.parse_args()
+
+
+def compare_videoreader_with_decord(filename: str):
+    """
+    This function compares the PyVideoReader and Decord libraries by reading frames from a video file
+    and checking if the frames match in shape and pixel values. It prints the number of matching frames and
+    the differences found, if any.
+
+    Not 100% accurate, but a good sanity check.
+
+    Output using input.mp4:
+    Frame count comparison: PyVideoReader=100, Decord=100
+    Found 17 differences:
+        Diff 1: Frame 83, Shape match: True, Shapes: (240, 320, 3) vs (240, 320, 3), Pixel diff: 127.48
+        Diff 2: Frame 84, Shape match: True, Shapes: (240, 320, 3) vs (240, 320, 3), Pixel diff: 127.52
+        Diff 3: Frame 85, Shape match: True, Shapes: (240, 320, 3) vs (240, 320, 3), Pixel diff: 127.51
+        Diff 4: Frame 86, Shape match: True, Shapes: (240, 320, 3) vs (240, 320, 3), Pixel diff: 127.46
+        Diff 5: Frame 87, Shape match: True, Shapes: (240, 320, 3) vs (240, 320, 3), Pixel diff: 127.31
+        Diff 6: Frame 88, Shape match: True, Shapes: (240, 320, 3) vs (240, 320, 3), Pixel diff: 127.21
+        Diff 7: Frame 89, Shape match: True, Shapes: (240, 320, 3) vs (240, 320, 3), Pixel diff: 127.03
+        Diff 8: Frame 90, Shape match: True, Shapes: (240, 320, 3) vs (240, 320, 3), Pixel diff: 126.61
+        Diff 9: Frame 91, Shape match: True, Shapes: (240, 320, 3) vs (240, 320, 3), Pixel diff: 126.43
+        Diff 10: Frame 92, Shape match: True, Shapes: (240, 320, 3) vs (240, 320, 3), Pixel diff: 126.37
+        Diff 11: Frame 93, Shape match: True, Shapes: (240, 320, 3) vs (240, 320, 3), Pixel diff: 126.27
+        Diff 12: Frame 94, Shape match: True, Shapes: (240, 320, 3) vs (240, 320, 3), Pixel diff: 126.28
+        Diff 13: Frame 95, Shape match: True, Shapes: (240, 320, 3) vs (240, 320, 3), Pixel diff: 126.23
+        Diff 14: Frame 96, Shape match: True, Shapes: (240, 320, 3) vs (240, 320, 3), Pixel diff: 126.33
+        Diff 15: Frame 97, Shape match: True, Shapes: (240, 320, 3) vs (240, 320, 3), Pixel diff: 126.42
+        Diff 16: Frame 98, Shape match: True, Shapes: (240, 320, 3) vs (240, 320, 3), Pixel diff: 126.57
+        Diff 17: Frame 99, Shape match: True, Shapes: (240, 320, 3) vs (240, 320, 3), Pixel diff: 126.69
+    """
+    print("\n===== Comparing PyVideoReader with Decord =====")
+    vr_reader = PyVideoReader(filename)
+    decord_reader = VideoReader(filename, num_threads=1)
+    vr_frames = []
+    decord_frames = []
+    print("Reading frames from PyVideoReader...")
+    for frame in vr_reader:
+        vr_frames.append(frame.copy())
+    print("Reading frames from Decord...")
+    for i in range(len(decord_reader)):
+        decord_frames.append(decord_reader[i].asnumpy())
+    print(f"Frame count comparison: PyVideoReader={len(vr_frames)}, Decord={len(decord_frames)}")
+
+    min_frames = min(len(vr_frames), len(decord_frames))
+    matches = 0
+    differences = []
+    print(f"Comparing {min_frames} frames...")
+
+    for i in range(min_frames):
+        vr_frame = vr_frames[i]
+        decord_frame = decord_frames[i]
+        shape_match = vr_frame.shape == decord_frame.shape
+        if shape_match:
+            diff = np.mean(np.abs(vr_frame.astype(np.float32) - decord_frame.astype(np.float32)))
+            content_match = diff < 1.0
+        else:
+            content_match = False
+            diff = float("inf")
+        if shape_match and content_match:
+            matches += 1
+        else:
+            differences.append(
+                {
+                    "frame": i,
+                    "shape_match": shape_match,
+                    "vr_shape": vr_frame.shape,
+                    "decord_shape": decord_frame.shape,
+                    "pixel_diff": diff,
+                }
+            )
+    print(f"\nResults: {matches}/{min_frames} frames match exactly ({matches / min_frames * 100:.2f}%)")
+    if differences:
+        print(f"Found {len(differences)} differences:")
+        for i, diff in enumerate(differences):
+            print(
+                f"  Diff {i + 1}: Frame {diff['frame']}, Shape match: {diff['shape_match']}, "
+                f"Shapes: {diff['vr_shape']} vs {diff['decord_shape']}, Pixel diff: {diff['pixel_diff']:.2f}"
+            )
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    filename = Path(args.filename)
+    compare_videoreader_with_decord(str(filename))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ mod reader;
 use convert::rgb2gray;
 use decoder::DecoderConfig;
 use log::debug;
-use ndarray::s;
+use ndarray::{s, Array4};
 use pyo3::{
     exceptions::{PyRuntimeError, PyStopIteration},
     pyclass, pymethods, pymodule,
@@ -21,6 +21,7 @@ use pyo3::{
 };
 use reader::VideoReader;
 use std::sync::Mutex;
+use std::collections::VecDeque;
 
 use once_cell::sync::Lazy;
 use tokio::runtime::{self, Runtime};
@@ -33,17 +34,20 @@ static RUNTIME: Lazy<Runtime> = Lazy::new(|| {
 });
 
 type Frame = PyArray<u8, Dim<[usize; 3]>>;
+type FrameArray = Array4<u8>;
 
 #[pyclass]
 struct PyVideoReader {
     inner: Mutex<VideoReader>,
     current_frame: usize,
+    frame_buffer: VecDeque<FrameArray>,
+    chunk_size: usize,
 }
 
 #[pymethods]
 impl PyVideoReader {
     #[new]
-    #[pyo3(signature = (filename, threads=None, resize_shorter_side=None, resize_longer_side=None, device=None, filter=None))]
+    #[pyo3(signature = (filename, threads=None, resize_shorter_side=None, resize_longer_side=None, device=None, filter=None, chunk_size=None))]
     /// create an instance of VideoReader
     /// * `filename` - path to the video file
     /// * `threads` - number of threads to use. If None, let ffmpeg choose the optimal number.
@@ -54,6 +58,7 @@ impl PyVideoReader {
     /// * `device` - type of hardware acceleration, eg: 'cuda', 'vdpau', 'drm', etc.
     /// * `filter` - custome ffmpeg filter to use, eg "format=rgb24,scale=w=256:h=256:flags=fast_bilinear"
     /// If set to None (default) or 'cpu' then cpu is used.
+    /// * `chunk_size` - number of frames to decode in each batch for iterator (default: 32)
     /// * returns a PyVideoReader instance.
     fn new(
         filename: &str,
@@ -62,6 +67,7 @@ impl PyVideoReader {
         resize_longer_side: Option<f64>,
         device: Option<&str>,
         filter: Option<String>,
+        chunk_size: Option<usize>,
     ) -> PyResult<Self> {
         let hwaccel = match device {
             Some("cpu") | None => None,
@@ -77,7 +83,9 @@ impl PyVideoReader {
         match VideoReader::new(filename.to_string(), decoder_config) {
             Ok(reader) => Ok(PyVideoReader {
                 inner: Mutex::new(reader),
-                current_frame: 0, // Initialize current frame index
+                current_frame: 0,
+                frame_buffer: VecDeque::new(),
+                chunk_size: chunk_size.unwrap_or(32),
             }),
             Err(e) => Err(PyRuntimeError::new_err(format!("Error: {}", e))),
         }
@@ -91,29 +99,19 @@ impl PyVideoReader {
         &mut self,
         py: Python<'a>,
     ) -> PyResult<Bound<'a, PyArray<u8, Dim<[usize; 3]>>>> {
-        match self.inner.lock() {
-            Ok(mut vr) => {
-                let total_frames = *vr.stream_info().frame_count();
+        // Refill buffer if empty
+        if self.frame_buffer.is_empty() {
+            self.refill_buffer()?;
+        }
 
-                if self.current_frame >= total_frames {
-                    self.current_frame = 0; // Reset for next iteration
-                    return Err(PyStopIteration::new_err("No more frames"));
-                }
-
-                // Use internal get_batch method - no "with_fallback" parameter
-                match vr.get_batch(vec![self.current_frame]) {
-                    Ok(batch) => {
-                        let frame = batch.slice(s![0, .., .., ..]).to_owned();
-                        self.current_frame += 1;
-                        Ok(frame.into_pyarray(py))
-                    }
-                    Err(e) => Err(PyRuntimeError::new_err(format!(
-                        "Error getting frame: {}",
-                        e
-                    ))),
-                }
-            }
-            Err(e) => Err(PyRuntimeError::new_err(format!("Lock error: {}", e))),
+        if let Some(frame) = self.frame_buffer.pop_front() {
+            self.current_frame += 1;
+            Ok(frame.into_pyarray(py))
+        } else {
+            // Should reset for next iteration
+            self.current_frame = 0;
+            self.frame_buffer.clear();
+            Err(PyStopIteration::new_err("No more frames"))
         }
     }
 
@@ -251,7 +249,6 @@ impl PyVideoReader {
     ) -> PyResult<Bound<'a, PyArray<u8, Dim<[usize; 4]>>>> {
         match self.inner.lock() {
             Ok(mut vr) => {
-                // let video: Array4<u8>;
                 let start_time: i32 = vr
                     .decoder()
                     .video_info()
@@ -299,11 +296,42 @@ impl PyVideoReader {
             Err(e) => Err(PyRuntimeError::new_err(format!("Lock error: {}", e))),
         }
     }
+
+    /// Reset the iterator to start from the beginning
+    fn reset(&mut self) -> PyResult<()> {
+        self.current_frame = 0;
+        self.frame_buffer.clear();
+        Ok(())
+    }
 }
 
-#[pymodule]
-fn video_reader<'py>(_py: Python<'py>, m: &Bound<'py, PyModule>) -> PyResult<()> {
-    env_logger::init();
-    m.add_class::<PyVideoReader>()?;
-    Ok(())
+impl PyVideoReader {
+    /// Refill the frame buffer with the next chunk of frames
+    fn refill_buffer(&mut self) -> PyResult<()> {
+        match self.inner.lock() {
+            Ok(mut vr) => {
+                let total_frames = *vr.stream_info().frame_count();
+                
+                if self.current_frame >= total_frames {
+                    return Ok(()); // No more frames to load
+                }
+
+                let end_frame = (self.current_frame + self.chunk_size).min(total_frames);
+                let indices: Vec<usize> = (self.current_frame..end_frame).collect();
+
+                match vr.get_batch(indices) {
+                    Ok(batch) => {
+                        // Convert 4D batch to individual 3D frames and add to buffer
+                        for i in 0..(end_frame - self.current_frame) {
+                            let frame = batch.slice(s![i, .., .., ..]).to_owned();
+                            self.frame_buffer.push_back(frame);
+                        }
+                        Ok(())
+                    }
+                    Err(e) => Err(PyRuntimeError::new_err(format!("Error loading chunk: {}", e)))
+                }
+            }
+            Err(e) => Err(PyRuntimeError::new_err(format!("Lock error: {}", e)))
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ use convert::rgb2gray;
 use decoder::DecoderConfig;
 use log::debug;
 use pyo3::{
-    exceptions::PyRuntimeError, PyRef, PyStopIteration,
+    exceptions::{PyRuntimeError, PyStopIteration}, PyRef,
     pyclass, pymethods, pymodule,
     types::{IntoPyDict, PyDict, PyFloat, PyList, PyModule, PyModuleMethods},
     Bound, PyResult, Python,
@@ -97,7 +97,7 @@ impl PyVideoReader {
                     return Err(PyStopIteration::new_err("No more frames"));
                 }
                 
-                match vr.get_batch(vec![self.current_frame], false) {
+                match vr.get_batch(vec![self.current_frame]) {
                     Ok(batch) => {
                         let frame = batch.slice(s![0, .., .., ..]).to_owned();
                         self.current_frame += 1;


### PR DESCRIPTION
This addresses issue https://github.com/gcanat/video_reader-rs/issues/54

As you mentioned, performance is not ideal, the constant back and forth does come with drawbacks.
It does lower the memory footprint significantly because it removes the vagueness associated through using a set hardcoded `batchsize` and it should allow for broader coverage for lower end systems that are more RAM restricted.

You should now be able to do something like
```py
frames = PyVideoReader("input.mp4")

for frame in frames:
    print(frame.shape)

```

I believe most of the performance overhead could be negated through using a more robust decode method where a set X amount of frames are decoded in memory and ready to be accessed, say 3 frames are decoded and appended to a list instead of 1 frame at a time and each iteration first checks if any frames are in the list, but my rust knowledge is poor to say the least and I would need your help to thinker more with it. 

I believe this should work in parallel with the batch approach you already had in place so it shouldn't disrupt any workflows.

Python 3.8 has reached EOL near the end of 2024 based on https://devguide.python.org/versions/ , this PR also removes support for it.

I also added a script to check if the output of pyvideoreader matches decord 1:1 and if not it prints it to the terminal, example output is provided at the beginning of the function. ( see scripts\test_frame_iterator )

Please let me know if you see any issue and what you think about this, it should align better with other tools whilst also making it simpler to utilize.

NOTE: I have yet to check if `decode_fast` works!