### PR TITLE
build.yml: refactor to support riscv64 builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
           #   target: ppc64le
     env:
       FFMPEG_DIR: ${{ github.workspace }}/ffmpeg
-      FFMPEG_VERS: 8.0.1-5
+      FFMPEG_VERS: 8.1.1-2
       FFMPEG_BASE_URL: https://github.com/PyAV-Org/pyav-ffmpeg/releases/download
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,17 +18,13 @@ jobs:
       matrix:
         platform:
           - runner: ubuntu-24.04
-            target: x86_64
+            target: x86_64-unknown-linux-gnu
+            arch: x86_64
+            manylinux: 2_34
           - runner: ubuntu-24.04-arm
-            target: aarch64
-          # - runner: ubuntu-latest
-          #   target: x86
-          # - runner: ubuntu-latest
-          #   target: armv7
-          # - runner: ubuntu-latest
-          #   target: s390x
-          # - runner: ubuntu-latest
-          #   target: ppc64le
+            target: aarch64-unknown-linux-gnu
+            arch: aarch64
+            manylinux: 2_34
     env:
       FFMPEG_DIR: ${{ github.workspace }}/ffmpeg
       FFMPEG_VERS: 8.1.1-2
@@ -47,7 +43,7 @@ jobs:
         id: download_url
         run: |
           DOWNLOAD_URL=$(
-            echo "${{ env.FFMPEG_BASE_URL }}/${{ env.FFMPEG_VERS }}/ffmpeg-manylinux-${{ matrix.platform.target }}.tar.gz";
+            echo "${{ env.FFMPEG_BASE_URL }}/${{ env.FFMPEG_VERS }}/ffmpeg-manylinux-${{ matrix.platform.arch }}.tar.gz";
           )
           echo "ffmpeg_url=$DOWNLOAD_URL" >> $GITHUB_OUTPUT
 
@@ -61,12 +57,12 @@ jobs:
             mkdir -p ${{ env.FFMPEG_DIR }}
             tar -zxf ffmpeg.tar.gz -C ${{ env.FFMPEG_DIR }}
           args: --release --out dist --interpreter '3.9 3.10 3.11 3.12 3.13 3.13t 3.14 3.14t pypy3.11'
-          manylinux: 2_34
+          manylinux: ${{ matrix.platform.manylinux }}
           docker-options: -e CI -e FFMPEG_DIR=${{ env.FFMPEG_DIR }}
       - name: Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: wheels-linux-${{ matrix.platform.target }}
+          name: wheels-linux-${{ matrix.platform.arch }}
           path: dist
 
   # musllinux:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,45 +69,6 @@ jobs:
           name: wheels-linux-${{ matrix.platform.arch }}
           path: dist
 
-  # musllinux:
-  #   runs-on: ${{ matrix.platform.runner }}
-  # env:
-  #   FFMPEG_DOWNLOAD_URL: "https://www.dropbox.com/scl/fi/x76nti8wr8qqoyyxvifa8/ffmpeg-4.4-linux-clang-default.tar.xz?rlkey=${{ secrets.DROPBOX_TOKEN }}&dl=1"
-  #   FFMPEG_DIR: ${{ github.workspace }}/ffmpeg
-  #   strategy:
-  #     matrix:
-  #       platform:
-  #         - runner: ubuntu-latest
-  #           target: x86_64
-  #         - runner: ubuntu-latest
-  #           target: x86
-  #         - runner: ubuntu-latest
-  #           target: aarch64
-  #         - runner: ubuntu-latest
-  #           target: armv7
-  #   steps:
-  #     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
-  #     - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-  #       with:
-  #         python-version: '3.11'
-  #   - name: Build wheels
-  #     uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
-  #     with:
-  #       target: ${{ matrix.platform.target }}
-  #       before-script-linux: |
-  #         yum install -y clang libXv-devel xz alsa-lib-devel &&
-  #         python3 -m ensurepip && pip install "maturin>=1.3,<2.0" patchelf &&
-  #         curl -L ${{ env.FFMPEG_DOWNLOAD_URL }} -o ffmpeg.tar.xz && mkdir -p ${{ env.FFMPEG_DIR }} &&
-  #         tar -xf ffmpeg.tar.xz -C ${{ env.FFMPEG_DIR }} --strip-components=1 &&
-  #         export FFMPEG_DIR=${{ env.FFMPEG_DIR }}
-  #       args: --release --out dist --find-interpreter
-  #       manylinux: 2_28
-  #     - name: Upload wheels
-  #       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
-  #       with:
-  #         name: wheels-musllinux-${{ matrix.platform.target }}
-  #         path: dist
-
   windows:
     runs-on: ${{ matrix.platform.runner }}
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,10 @@ jobs:
             target: aarch64-unknown-linux-gnu
             arch: aarch64
             manylinux: 2_34
+          - runner: ubuntu-24.04-riscv
+            target: riscv64gc-unknown-linux-gnu
+            arch: riscv64
+            manylinux: 2_39
     env:
       FFMPEG_DIR: ${{ github.workspace }}/ffmpeg
       FFMPEG_VERS: 8.1.1-2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,9 +37,11 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           persist-credentials: false
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           python-version: '3.11'
+          activate-environment: true
+          enable-cache: false
 
       - name: Set download url
         id: download_url

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
             curl -L "${{ steps.download_url.outputs.ffmpeg_url }}" -o ffmpeg.tar.gz
             mkdir -p ${{ env.FFMPEG_DIR }}
             tar -zxf ffmpeg.tar.gz -C ${{ env.FFMPEG_DIR }}
-          args: --release --out dist --interpreter '3.9 3.10 3.11 3.12 3.13 3.13t 3.14 3.14t pypy3.11'
+          args: --release --out dist --interpreter '3.9 3.10 3.11 3.12 3.13 3.14 3.14t pypy3.11'
           manylinux: ${{ matrix.platform.manylinux }}
           docker-options: -e CI -e FFMPEG_DIR=${{ env.FFMPEG_DIR }}
       - name: Upload wheels


### PR DESCRIPTION
There are several things we have to do here, some of which aren't strictly riscv64-related, but they should be useful in general. In order:

1. Switch from using `actions/setup-python` to `astral-sh/setup-uv`, which is more versatile for checkouts but requires the addition of the `activate-environment` and `enable-cache` fields to ensure Python is still usable in the same way
2. Update `FFMPEG_VERS` to `8.1.1-2` for `linux` - there are earlier ones that support riscv64, but this is the latest release, so use that and get that update out of the way.
3. Update the build matrix for `linux` - some architectures like riscv64 don't have a toolchain name which matches their architecture string, so differentiate between them in the existing matrix. `manylinux` is also specified, because like the toolchain names, different architectures may use different versions. Also remove the commented-out architectures since they're easy to re-implement if they're ever needed (but IMO they're not high-priority?)
4. Add `runner: ubuntu-24.04-riscv` (more about this below), `arch: riscv64`, `target: riscv64gc-unknown-linux-gnu`, and `manylinux: 2_39` for the riscv64 build case.
5. Remove the commented `musllinux` block. Same idea as before - it's not being used, so remove the clutter. This patch could be dropped if you prefer to keep it.
6. Remove `3.13t` from the interpreter target list for maturin - this seems to break with newer versions, and IMO 3.13t is likely to be low-priority anyway, especially with 3.15 coming soon.

To make the native riscv64 builds possible, the video_reader-rs repository will have to enable the RISE RISC-V Runners [app](https://github.com/apps/rise-risc-v-runners). You can find out more about this on the RISE Project's [page](https://riscv-runners.riseproject.dev/) about it, but essentially RISE has partnered with Cloud-V and Scaleway to provide riscv64 machines free-of-charge, with the goal of accelerating RISC-V support across open-source ecosystems. This is where the aforementioned `ubuntu-24.04-riscv` runner comes from - all of the work is already done to handle runner setup and scheduling, so once the app is enabled for the project, then they're usable like any other runner.

This PR's Actions runs may fail at first because that app isn't automatically enabled (the maintainer will have to do it), and so the riscv64 run will wait forever to find a suitable runner. To show that it does work, I've enabled the RISE RISC-V Runners app at the "Personal" level on my fork of this project, and run a build: https://github.com/threexc/video_reader-rs/actions/runs/28174716895